### PR TITLE
enable GitHub dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
this enables the version updates for the GitHub Actions and the python dependencies.

see [the docs] for further details.

[the docs]: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates