### PR TITLE
remove author & copyright from Klims in `app.py`

### DIFF
--- a/src/app_stored_images/app.py
+++ b/src/app_stored_images/app.py
@@ -1,6 +1,3 @@
-__author__ = "KLSA"
-__copyright__ = "Copyright 2023 to Infinity and Beyond, CEDES AG"
-
 from typing import Optional
 
 import cv2


### PR DESCRIPTION
this was automatically generated by his IDE when he created the app, however this is not appropriate anymore as the file has been heavily edited (the files which remain largely unchanged in turn don't have a copyright & author notice anyway).

Klims by email confirmed that the files can be licensed as GPLv3 and the commit introducing them was done with him as author, thus authorship is still established. as the code was provided by him at the FHGR it is also unrelated to CEDES (his regular employer).