### PR TITLE
fix python wheel distribution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,8 @@ version = "0.1.0"
 description = ""
 authors = ["Dominic Eicher <nic.eicher@sunrise.ch>", "Ralph Ursprung <ralph.ursprung@gmail.com>", "Klims Saikins <klims.saikins@cedes.com>"]
 readme = "README.md"
-packages = [{include = "test", from = "src"}]
+packages = [{include = "**/*", from = "src"}]
+exclude = ["src/test"]
 
 [tool.poetry.dependencies]
 python = "^3.10"


### PR DESCRIPTION
so far the wheel only included the `test` package - which is the only one which we _don't_ want to distribute.

now we include all our packages, excluding the `test` package. this way the wheel is usable.

fixes #22